### PR TITLE
fix duplicate question method

### DIFF
--- a/chars.wren
+++ b/chars.wren
@@ -18,7 +18,6 @@ class Chars {
   static slash { 0x2f }
 
   static zero { 0x30 }
-  static question { 0x3f }
   static nine { 0x39 }
 
   static colon { 0x3a }


### PR DESCRIPTION
with: `wren wrenalyzer.wren`

```
[chars line 28] Error at 'question': Class Chars already defines a static method 'question'.
Could not compile module 'chars'.
[lexer line 1] in (script)
```

I kept the one that followed numerically after `3e` for consistency.
